### PR TITLE
ci: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
+# The LAST matching line takes precedence.
+
 * @minvws/brba-php-codeowners
+.github/CODEOWNERS @minvws/irealisatie-operations


### PR DESCRIPTION
Add @minvws/irealisatie-operations as code owner for `.github/CODEOWNERS` and simplify the comment about rule precedence (see [the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for details).
